### PR TITLE
Add Base64 and ROT-N encoding/decoding tools

### DIFF
--- a/src/toys/base64/index.tsx
+++ b/src/toys/base64/index.tsx
@@ -7,11 +7,11 @@ import { useTitle } from "../../hooks/useTitle.ts";
 import { toy } from "../../utils.ts";
 
 function toUrlSafe(b64: string): string {
-  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return b64.replaceAll("+", "-").replaceAll("/", "_").replaceAll(/=+$/g, "");
 }
 
 function fromUrlSafe(b64: string): string {
-  let s = b64.replace(/-/g, "+").replace(/_/g, "/");
+  let s = b64.replaceAll("-", "+").replaceAll("_", "/");
   while (s.length % 4) s += "=";
   return s;
 }
@@ -28,23 +28,23 @@ function Base64Tool() {
       const encoded = btoa(
         new TextEncoder()
           .encode(input)
-          .reduce((acc, byte) => acc + String.fromCharCode(byte), ""),
+          .reduce((acc, byte) => acc + String.fromCodePoint(byte), ""),
       );
       setOutput(urlSafe ? toUrlSafe(encoded) : encoded);
       setError("");
-    } catch (e) {
-      setError(`Encode error: ${e instanceof Error ? e.message : e}`);
+    } catch (error_) {
+      setError(`Encode error: ${error_ instanceof Error ? error_.message : error_}`);
     }
   };
 
   const decode = () => {
     try {
       const b64 = urlSafe ? fromUrlSafe(input) : input;
-      const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+      const bytes = Uint8Array.from(atob(b64), (c) => c.codePointAt(0)!);
       setOutput(new TextDecoder().decode(bytes));
       setError("");
-    } catch (e) {
-      setError(`Decode error: ${e instanceof Error ? e.message : e}`);
+    } catch (error_) {
+      setError(`Decode error: ${error_ instanceof Error ? error_.message : error_}`);
     }
   };
 

--- a/src/toys/base64/index.tsx
+++ b/src/toys/base64/index.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import toast from "react-hot-toast";
+import { FaRegCopy } from "react-icons/fa";
+
+import { ToyMainBox, ToyMainBoxesContainer } from "../../components/common.tsx";
+import { useTitle } from "../../hooks/useTitle.ts";
+import { toy } from "../../utils.ts";
+
+function toUrlSafe(b64: string): string {
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromUrlSafe(b64: string): string {
+  let s = b64.replace(/-/g, "+").replace(/_/g, "/");
+  while (s.length % 4) s += "=";
+  return s;
+}
+
+function Base64Tool() {
+  useTitle("Base64");
+  const [input, setInput] = React.useState("");
+  const [output, setOutput] = React.useState("");
+  const [urlSafe, setUrlSafe] = React.useState(false);
+  const [error, setError] = React.useState("");
+
+  const encode = () => {
+    try {
+      const encoded = btoa(
+        new TextEncoder()
+          .encode(input)
+          .reduce((acc, byte) => acc + String.fromCharCode(byte), ""),
+      );
+      setOutput(urlSafe ? toUrlSafe(encoded) : encoded);
+      setError("");
+    } catch (e) {
+      setError(`Encode error: ${e instanceof Error ? e.message : e}`);
+    }
+  };
+
+  const decode = () => {
+    try {
+      const b64 = urlSafe ? fromUrlSafe(input) : input;
+      const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+      setOutput(new TextDecoder().decode(bytes));
+      setError("");
+    } catch (e) {
+      setError(`Decode error: ${e instanceof Error ? e.message : e}`);
+    }
+  };
+
+  const handleCopy = () => {
+    if (output) {
+      navigator.clipboard.writeText(output);
+      toast.success("Copied to clipboard");
+    }
+  };
+
+  return (
+    <ToyMainBoxesContainer>
+      <ToyMainBox title="Input">
+        <textarea
+          className="textarea w-full sm:min-w-96 md:min-w-xl min-h-48 font-mono text-sm"
+          placeholder="Enter text to encode or base64 to decode..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <div className="flex gap-2 mt-2 items-center flex-wrap">
+          <button className="btn btn-primary" onClick={encode}>
+            Encode
+          </button>
+          <button className="btn btn-secondary" onClick={decode}>
+            Decode
+          </button>
+          <label className="label cursor-pointer gap-2">
+            <input
+              type="checkbox"
+              className="checkbox"
+              checked={urlSafe}
+              onChange={(e) => setUrlSafe(e.target.checked)}
+            />
+            URL-safe
+          </label>
+        </div>
+      </ToyMainBox>
+      <ToyMainBox title="Output">
+        {error ? (
+          <div className="alert alert-error">{error}</div>
+        ) : (
+          <textarea
+            className="textarea w-full sm:min-w-96 md:min-w-xl min-h-48 font-mono text-sm"
+            readOnly
+            value={output}
+          />
+        )}
+        <div className="flex gap-2 mt-2">
+          <button className="btn btn-ghost" disabled={!output || !!error} onClick={handleCopy}>
+            <FaRegCopy /> Copy
+          </button>
+        </div>
+      </ToyMainBox>
+    </ToyMainBoxesContainer>
+  );
+}
+
+export const base64 = toy("base64", "Base64", Base64Tool);

--- a/src/toys/rot-n/index.tsx
+++ b/src/toys/rot-n/index.tsx
@@ -75,4 +75,4 @@ function RotN() {
   );
 }
 
-export const rotN = toy("rot-n", "ROT-N", RotN);
+export const rotNToy = toy("rot-n", "ROT-N", RotN);

--- a/src/toys/rot-n/index.tsx
+++ b/src/toys/rot-n/index.tsx
@@ -9,9 +9,9 @@ import { toy } from "../../utils.ts";
 function rotN(text: string, n: number): string {
   return [...text]
     .map((ch) => {
-      const code = ch.charCodeAt(0);
-      if (code >= 65 && code <= 90) return String.fromCharCode(((code - 65 + n) % 26) + 65);
-      if (code >= 97 && code <= 122) return String.fromCharCode(((code - 97 + n) % 26) + 97);
+      const code = ch.codePointAt(0)!;
+      if (code >= 65 && code <= 90) return String.fromCodePoint(((code - 65 + n) % 26) + 65);
+      if (code >= 97 && code <= 122) return String.fromCodePoint(((code - 97 + n) % 26) + 97);
       return ch;
     })
     .join("");

--- a/src/toys/rot-n/index.tsx
+++ b/src/toys/rot-n/index.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import toast from "react-hot-toast";
+import { FaRegCopy } from "react-icons/fa";
+
+import { ToyMainBox, ToyMainBoxesContainer } from "../../components/common.tsx";
+import { useTitle } from "../../hooks/useTitle.ts";
+import { toy } from "../../utils.ts";
+
+function rotN(text: string, n: number): string {
+  return [...text]
+    .map((ch) => {
+      const code = ch.charCodeAt(0);
+      if (code >= 65 && code <= 90) return String.fromCharCode(((code - 65 + n) % 26) + 65);
+      if (code >= 97 && code <= 122) return String.fromCharCode(((code - 97 + n) % 26) + 97);
+      return ch;
+    })
+    .join("");
+}
+
+function RotN() {
+  useTitle("ROT-N");
+  const [input, setInput] = React.useState("");
+  const [n, setN] = React.useState(13);
+
+  const output = React.useMemo(() => rotN(input, ((n % 26) + 26) % 26), [input, n]);
+
+  const handleCopy = () => {
+    if (output) {
+      navigator.clipboard.writeText(output);
+      toast.success("Copied to clipboard");
+    }
+  };
+
+  return (
+    <ToyMainBoxesContainer>
+      <ToyMainBox title="Input">
+        <textarea
+          className="textarea w-full sm:min-w-96 md:min-w-xl min-h-48 font-mono text-sm"
+          placeholder="Enter text to rotate..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <div className="flex gap-2 mt-2 items-center">
+          <label className="label gap-2">
+            N
+            <input
+              type="number"
+              className="input input-bordered w-20 font-mono"
+              min={0}
+              max={25}
+              value={n}
+              onChange={(e) => setN(Number(e.target.value))}
+            />
+          </label>
+          {n !== 13 && (
+            <button className="btn btn-ghost btn-sm" onClick={() => setN(13)}>
+              Reset to 13
+            </button>
+          )}
+        </div>
+      </ToyMainBox>
+      <ToyMainBox title="Output">
+        <textarea
+          className="textarea w-full sm:min-w-96 md:min-w-xl min-h-48 font-mono text-sm"
+          readOnly
+          value={output}
+        />
+        <div className="flex gap-2 mt-2">
+          <button className="btn btn-ghost" disabled={!output} onClick={handleCopy}>
+            <FaRegCopy /> Copy
+          </button>
+        </div>
+      </ToyMainBox>
+    </ToyMainBoxesContainer>
+  );
+}
+
+export const rotN = toy("rot-n", "ROT-N", RotN);


### PR DESCRIPTION
## Summary
This PR adds two new utility tools to the toys collection: a Base64 encoder/decoder and a ROT-N cipher tool. Both tools provide interactive interfaces for text transformation with copy-to-clipboard functionality.

## Key Changes
- **Base64 Tool** (`src/toys/base64/index.tsx`):
  - Encode plain text to Base64 and decode Base64 back to text
  - Support for URL-safe Base64 encoding (replacing `+` with `-`, `/` with `_`, and removing padding)
  - Error handling for invalid inputs
  - Copy output to clipboard with toast notification

- **ROT-N Tool** (`src/toys/rot-n/index.tsx`):
  - Rotate alphabetic characters by N positions (Caesar cipher variant)
  - Support for both uppercase and lowercase letters
  - Real-time output as user types
  - Configurable rotation value (0-25) with quick reset to ROT-13
  - Copy output to clipboard with toast notification

## Implementation Details
- Both tools follow the existing toy component pattern with `ToyMainBox` and `ToyMainBoxesContainer` layout
- Proper error handling in Base64 tool for encoding/decoding failures
- ROT-N uses memoization to optimize output calculation
- Consistent UI with disabled copy buttons when output is empty or invalid
- Both tools use the `useTitle` hook to set page title

https://claude.ai/code/session_011MTZ8obwiV4LMLcSPDtM75